### PR TITLE
Added warning about uninitialized memory. 

### DIFF
--- a/source/processes.rst
+++ b/source/processes.rst
@@ -33,8 +33,8 @@ exits. This is achieved using ``uv_spawn``.
 
 Note: ``options``, being a global variable, is implicitly initialized with 
 zeros.  If you change ``options`` to a local variable, memory corruption 
-will follow (thanks Valgrind for saving me hours!).  You can use ``memset`` 
-to initialize a local variable of type ``uv_process_options_t``.
+will follow (thanks Valgrind for saving me a few hours!).  You can use 
+``memset`` to initialize a local variable of type ``uv_process_options_t``.
 
 The ``uv_process_t`` struct only acts as the watcher, all options are set via
 ``uv_process_options_t``. To simply launch a process, you need to set only the


### PR DESCRIPTION
Added warning about uninitialized memory.  The example code does not make it clear that the "options" variable must be initialized to zero before use.  

This helped me write a bug which took a few minutes to find with the help of Valgrind.
