### PR TITLE
Add curl into the LIBS in the make file

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -39,7 +39,7 @@ SHARED_LIB_FLAGS=-bundle -undefined dynamic_lookup -o plugin/libhello.dylib
 endif
 
 ifeq (Linux, $(uname_S))
-LIBS=-lrt -ldl -lm -pthread
+LIBS=-lrt -ldl -lm -pthread -lcurl
 SHARED_LIB_FLAGS=-shared -Wl,-soname,libhello.so -o plugin/libhello.so
 PLUGIN_EXE_FLAGS=-Wl,-export-dynamic
 endif


### PR DESCRIPTION
## I'm using Ubuntu 12.04 64-bit,  and I run into this error during the make process:

/home/jason/github/uvbook/code/uvwget/main.c:50: undefined reference to `curl_easy_init'
/home/jason/github/uvbook/code/uvwget/main.c:51: undefined reference to`curl_easy_setopt'
## /home/jason/github/uvbook/code/uvwget/main.c:52: undefined reference to `curl_easy_setopt'

I added lcurl into the LIBS variable, the problem's gone.
