### PR TITLE
Updated example of creating a new loop.

### DIFF
--- a/code/helloworld/main.c
+++ b/code/helloworld/main.c
@@ -8,6 +8,9 @@ int main() {
   
     printf("Now quitting.\n");
     uv_run(loop, UV_RUN_DEFAULT);
+    
+    uv_loop_close(loop);
+    free(loop);
 
     return 0;
 }


### PR DESCRIPTION
Using uv_loop_new() to create a new event loop is now deprecated. 

From uv.h:

```
/*
* Allocates and initializes a new loop.
* NOTE: This function is DEPRECATED (to be removed after 0.12), users should
* allocate the loop manually and use uv_loop_init instead.
*/
UV_EXTERN uv_loop_t* uv_loop_new(void);
```
