### PR TITLE
Updated example of using uv_idle_cb callback.

### DIFF
--- a/code/idle-basic/main.c
+++ b/code/idle-basic/main.c
@@ -3,7 +3,7 @@
 
 int64_t counter = 0;
 
-void wait_for_a_while(uv_idle_t* handle, int status) {
+void wait_for_a_while(uv_idle_t* handle) {
     counter++;
 
     if (counter >= 10e6)


### PR DESCRIPTION
The status parameter was removed from the uv_idle_cb definition in commit saghul/libuv@db2a9072bce129630214904be5e2eedeaafc9835.

This change removes the status parameter from the callback in the example code.
