### PR TITLE
fix offset of on_open() code

### DIFF
--- a/source/filesystem.rst
+++ b/source/filesystem.rst
@@ -55,7 +55,7 @@ a callback for when the file is opened:
 .. rubric:: uvcat/main.c - opening a file
 .. literalinclude:: ../code/uvcat/main.c
     :linenos:
-    :lines: 42-54
+    :lines: 41-53
     :emphasize-lines: 4, 6-7
 
 The ``result`` field of a ``uv_fs_t`` is the file descriptor in case of the


### PR DESCRIPTION
Hi!

On the first code of this page, the original text doesn't show the beginning of the function.
https://nikhilm.github.io/uvbook/filesystem.html
