### PR TITLE
selects deprecated/removed pngmath module only for older versions of sphinx

### DIFF
--- a/code/helloworld/cmake/CMakeLists.txt
+++ b/code/helloworld/cmake/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required (VERSION 3.1)
+
+set(PROJECT_NAME helloworld)
+project(${PROJECT_NAME})
+
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_BUILD_TYPE Debug)
+
+add_executable(${PROJECT_NAME} src/main.cpp)
+link_directories("../../../libuv/.libs")
+target_link_libraries(${PROJECT_NAME} libuv.a)
+

--- a/code/helloworld/cmake/src/main.cpp
+++ b/code/helloworld/cmake/src/main.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <uv.h>
+
+struct my_idler {
+    uv_idle_t idler_;
+    int64_t counter = 0;
+};
+
+class UVManager {
+    typedef std::function<void(uv_idle_t*)> cb_t;
+private:
+    cb_t idle_cb_;
+    uv_loop_t loop_;
+    my_idler idler_;
+    UVManager(UVManager const & );
+    UVManager &operator=(UVManager const &);
+
+public:
+    UVManager() {
+        uv_loop_init(&loop_);
+    }
+
+    UVManager(uv_idle_cb icb) {
+        idle_cb_ = icb;
+        uv_loop_init(&loop_);
+        uv_idle_init(&loop_, (uv_idle_t*)&idler_);
+        uv_idle_start((uv_idle_t*)&idler_, icb);
+    }
+
+    virtual ~UVManager(){
+        uv_loop_close(&loop_);
+    }
+
+    void run(){
+        uv_run(&loop_, UV_RUN_DEFAULT);
+    }
+};
+
+int main() {
+    UVManager uvm(
+        [](uv_idle_t* handle) {
+            my_idler* my_h = (my_idler*)handle;
+            my_h->counter++;
+            if (my_h->counter >= 10e6)
+                uv_idle_stop(handle);
+        });
+    std::cout << "running the manager.." << std::endl;
+    uvm.run();
+    return 0;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys, os, sphinx, distutils.version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -25,7 +25,12 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig']
+
+if distutils.version.LooseVersion(sphinx.__version__) < distutils.version.LooseVersion('1.4'):
+    extensions.append('sphinx.ext.pngmath')
+else:
+    extensions.append('sphinx.ext.imgmath')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Apparently newer versions of sphinx (>=1.8) don't support the pngmath extension.  This patch selectively adds the extension for older versions.  Tested with Sphinx 1.8.2