### PR TITLE
update sphinx extension module

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.mathjax', 'sphinx.ext.ifconfig']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
## Issue

My attempt to build document with Sphinx v4.2.0 resulted in the following extension error:
> Extension error:
> Could not import extension sphinx.ext.pngmath (exception: No module named 'sphinx.ext.pngmath')
> make: *** [Makefile:50: html] Error 2

## Fix

It turns out that `sphinx.ext.pngmath` is a deprecated module since version v1.8, as mentioned [here](https://github.com/sphinx-doc/sphinx/issues/6182).

I was able to build uvbook after changing the module to `sphinx.ext.imgmath` in `source/conf.py`.